### PR TITLE
removed redundancy in userinfo stored in mongoDb

### DIFF
--- a/client/src/store/modules/user.js
+++ b/client/src/store/modules/user.js
@@ -48,7 +48,6 @@ export default {
           userInfo = response.data.filter(x => x.id === user.user.uid)
         })
         const userPayload = { id: userInfo[0].id, username: userInfo[0].username };
-        await axios.post('/api/users', userPayload);
         commit('SET_USER', userPayload);
       } catch (e) {
         commit('ERROR', e, { root: true });


### PR DESCRIPTION
### Why
Currently, we make the post request in the SignIn method to MongoDB which leads to redundancy in user data in the database

### Changes Done
UserInfo to be stored only once i.e. during signUp

### Testing
npm run serve (in root directory)
localhost:3000/api/users/
