### PR TITLE
Fixed cross-origin links

### DIFF
--- a/client/src/components/TheFooter.vue
+++ b/client/src/components/TheFooter.vue
@@ -5,7 +5,7 @@
         <span class="mr-6">&copy; {{ copy }}</span>
         <span>
           Build by
-          <a class="link" href="https://twitter.com/david_go__" target="_blank">@David_Go__</a>
+          <a class="link" href="https://twitter.com/david_go__" rel="noopener noreferrer" target="_blank">@David_Go__</a>
         </span>
       </v-container>
     </v-layout>


### PR DESCRIPTION
Hi @DavidGolodetsky , this PR is for fixing #13 as per the Google Lighthouse Best Practices report.

**Changes as a part of this PR:**

1. Added the `rel="noopener noreferrer"` to a link on `TheFooter.vue` component

This is the only one I could find in the entire project. There is already a protected link being generated on the `CardsList.vue` component. Please let me know if I missed converting any link.