### PR TITLE
fix user not existing on reload

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -50,6 +50,7 @@ import TheFooter from "@/components/TheFooter";
 import TheAlert from "@/components/TheAlert";
 import { mapState, mapActions, mapGetters } from "vuex";
 import { VueOfflineMixin } from "vue-offline";
+import { setupFb } from '@/db';
 
 export default {
   name: "App",
@@ -93,6 +94,9 @@ export default {
       if (window.pageYOffset > 500) this.showTop = true;
       if (this.showTop && window.pageYOffset < 500) this.showTop = false;
     }
+  },
+  mounted() {
+    setupFb()
   }
 };
 </script>

--- a/client/src/db.js
+++ b/client/src/db.js
@@ -40,4 +40,6 @@ export const fbStart = () => {
   ui.start('#firebaseui-auth-container', uiConfig);
 };
 
+export const setupFb = () => {}
+
 export default firebase;

--- a/client/src/store/modules/user.js
+++ b/client/src/store/modules/user.js
@@ -58,7 +58,9 @@ export default {
     autoSignIn({ commit }, payload) {
       commit('LOADING', true, { root: true });
       commit('SET_USER', { id: payload.uid });
-      router.push('/games');
+      if (router.currentRoute.path !== '/games') {
+        router.push('/games');
+      }
       commit('LOADING', false, { root: true });
     },
     async resetPassword({ commit }, payload) {


### PR DESCRIPTION
The problem with the user being not existing on page reload, is that firebase is not initialized on the home page (only on login screens). Therefore, i could just trigger the initialization of firebase in `App.vue` and let the already existing `autoSignIn` action do its magic

Closes #50 